### PR TITLE
Add Modal GPU CI pipeline for automated test execution

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,27 @@
+name: GPU Tests (L4)
+
+on:
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: Run tests on L4 GPU via Modal
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install Modal
+        run: pip install modal
+
+      - name: Run tests on B200
+        env:
+          MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
+          MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
+        run: modal run ci/modal_runner.py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,4 +24,4 @@ jobs:
         env:
           MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
           MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
-        run: modal run ci/modal_runner.py
+        run: modal run ci/modal_runner.py --ref ${{ github.sha }}

--- a/ci/modal_runner.py
+++ b/ci/modal_runner.py
@@ -17,7 +17,7 @@ image = (
         extra_index_url="https://download.pytorch.org/whl/cu128",
     )
     .run_commands(
-        "CXX=g++ CC=gcc pip install flash-attn --no-build-isolation",
+        "MAX_JOBS=4 CXX=g++ CC=gcc pip install flash-attn --no-build-isolation",
         gpu="L4",
     )
     .pip_install(

--- a/ci/modal_runner.py
+++ b/ci/modal_runner.py
@@ -13,6 +13,7 @@ image = (
         extra_index_url="https://download.pytorch.org/whl/cu128",
     )
     .run_commands(
+        "pip install packaging",
         "pip install flash-attn --no-build-isolation",
         gpu="L4",
     )

--- a/ci/modal_runner.py
+++ b/ci/modal_runner.py
@@ -1,0 +1,85 @@
+import modal
+
+app = modal.App("esm-efficient-tests")
+
+image = (
+    modal.Image.from_registry(
+        "nvidia/cuda:12.8.0-devel-ubuntu22.04",
+        add_python="3.11",
+    )
+    .pip_install(
+        "torch>=2.7.0",
+        extra_index_url="https://download.pytorch.org/whl/cu128",
+    )
+    .run_commands(
+        "pip install flash-attn --no-build-isolation",
+        gpu="L4",
+    )
+    .pip_install(
+        "einops",
+        "accelerate",
+        "pandas",
+        "numpy",
+        "polars",
+        "torchmetrics",
+        "lightning",
+        "scikit-learn",
+        "huggingface_hub",
+        "safetensors",
+        "pytest",
+        "pytest-runner",
+        "pooch",
+        "esm",
+    )
+    .run_commands(
+        "pip install git+https://github.com/MuhammedHasan/fair-esm.git",
+    )
+)
+
+# Cache downloaded model weights across runs (~800MB total)
+model_cache = modal.Volume.from_name("esm-model-cache", create_if_missing=True)
+
+
+@app.function(
+    gpu="L4",
+    image=image,
+    mounts=[modal.Mount.from_local_dir(".", remote_path="/app")],
+    volumes={"/model-cache": model_cache},
+    timeout=3600,
+)
+def run_tests():
+    import os
+    import shutil
+    import subprocess
+
+    os.chdir("/app")
+
+    # Restore cached model weights to avoid re-downloading each run
+    cache_dir = "/model-cache/test-data"
+    os.makedirs(cache_dir, exist_ok=True)
+    for fname in os.listdir(cache_dir):
+        dst = f"/app/tests/data/{fname}"
+        if not os.path.exists(dst):
+            shutil.copy2(f"{cache_dir}/{fname}", dst)
+
+    # Install the package itself
+    subprocess.run(["pip", "install", "-e", "."], check=True)
+
+    # Run tests
+    result = subprocess.run(["pytest", "tests/", "-v", "--tb=short"])
+
+    # Save newly downloaded models to cache
+    for fname in os.listdir("/app/tests/data"):
+        if fname.endswith((".pt", ".pth")):
+            dst = f"{cache_dir}/{fname}"
+            if not os.path.exists(dst):
+                shutil.copy2(f"/app/tests/data/{fname}", dst)
+    model_cache.commit()
+
+    if result.returncode != 0:
+        raise SystemExit(result.returncode)
+
+
+@app.local_entrypoint()
+def main():
+    run_tests.remote()

--- a/ci/modal_runner.py
+++ b/ci/modal_runner.py
@@ -37,9 +37,12 @@ image = (
         "pooch",
         "esm",
         "httpx",
+        "bitsandbytes",
     )
     .run_commands(
         "pip install git+https://github.com/MuhammedHasan/fair-esm.git",
+        # Patch fair-esm for PyTorch 2.6+ compatibility (weights_only default changed)
+        "sed -i 's/torch.load(str(model_location), map_location=\"cpu\")/torch.load(str(model_location), map_location=\"cpu\", weights_only=False)/' /usr/local/lib/python3.11/site-packages/fair_esm/pretrained.py",
     )
 )
 

--- a/ci/modal_runner.py
+++ b/ci/modal_runner.py
@@ -11,6 +11,8 @@ image = (
     .pip_install(
         "packaging",
         "ninja",
+        "wheel",
+        "setuptools",
         "torch>=2.7.0",
         extra_index_url="https://download.pytorch.org/whl/cu128",
     )

--- a/ci/modal_runner.py
+++ b/ci/modal_runner.py
@@ -34,6 +34,7 @@ image = (
     .run_commands(
         "pip install git+https://github.com/MuhammedHasan/fair-esm.git",
     )
+    .copy_local_dir(".", "/app")
 )
 
 # Cache downloaded model weights across runs (~800MB total)
@@ -43,7 +44,6 @@ model_cache = modal.Volume.from_name("esm-model-cache", create_if_missing=True)
 @app.function(
     gpu="L4",
     image=image,
-    mounts=[modal.Mount.from_local_dir(".", remote_path="/app")],
     volumes={"/model-cache": model_cache},
     timeout=3600,
 )

--- a/ci/modal_runner.py
+++ b/ci/modal_runner.py
@@ -7,7 +7,7 @@ image = (
         "nvidia/cuda:12.8.0-devel-ubuntu22.04",
         add_python="3.11",
     )
-    .apt_install("git")
+    .apt_install("git", "build-essential")
     .pip_install(
         "packaging",
         "ninja",

--- a/ci/modal_runner.py
+++ b/ci/modal_runner.py
@@ -9,11 +9,12 @@ image = (
     )
     .apt_install("git")
     .pip_install(
+        "packaging",
+        "ninja",
         "torch>=2.7.0",
         extra_index_url="https://download.pytorch.org/whl/cu128",
     )
     .run_commands(
-        "pip install packaging",
         "pip install flash-attn --no-build-isolation",
         gpu="L4",
     )

--- a/ci/modal_runner.py
+++ b/ci/modal_runner.py
@@ -35,6 +35,7 @@ image = (
         "pytest-runner",
         "pooch",
         "esm",
+        "httpx",
     )
     .run_commands(
         "pip install git+https://github.com/MuhammedHasan/fair-esm.git",

--- a/ci/modal_runner.py
+++ b/ci/modal_runner.py
@@ -7,6 +7,7 @@ image = (
         "nvidia/cuda:12.8.0-devel-ubuntu22.04",
         add_python="3.11",
     )
+    .apt_install("git")
     .pip_install(
         "torch>=2.7.0",
         extra_index_url="https://download.pytorch.org/whl/cu128",
@@ -34,7 +35,6 @@ image = (
     .run_commands(
         "pip install git+https://github.com/MuhammedHasan/fair-esm.git",
     )
-    .copy_local_dir(".", "/app")
 )
 
 # Cache downloaded model weights across runs (~800MB total)
@@ -47,12 +47,14 @@ model_cache = modal.Volume.from_name("esm-model-cache", create_if_missing=True)
     volumes={"/model-cache": model_cache},
     timeout=3600,
 )
-def run_tests():
+def run_tests(repo_url: str, ref: str):
     import os
     import shutil
     import subprocess
 
-    os.chdir("/app")
+    # Clone the repo at the specific commit
+    subprocess.run(["git", "clone", repo_url, "/app"], check=True)
+    subprocess.run(["git", "checkout", ref], cwd="/app", check=True)
 
     # Restore cached model weights to avoid re-downloading each run
     cache_dir = "/model-cache/test-data"
@@ -63,10 +65,10 @@ def run_tests():
             shutil.copy2(f"{cache_dir}/{fname}", dst)
 
     # Install the package itself
-    subprocess.run(["pip", "install", "-e", "."], check=True)
+    subprocess.run(["pip", "install", "-e", "."], cwd="/app", check=True)
 
     # Run tests
-    result = subprocess.run(["pytest", "tests/", "-v", "--tb=short"])
+    result = subprocess.run(["pytest", "tests/", "-v", "--tb=short"], cwd="/app")
 
     # Save newly downloaded models to cache
     for fname in os.listdir("/app/tests/data"):
@@ -81,5 +83,8 @@ def run_tests():
 
 
 @app.local_entrypoint()
-def main():
-    run_tests.remote()
+def main(
+    repo_url: str = "https://github.com/hmtcelik/esm-efficient.git",
+    ref: str = "master",
+):
+    run_tests.remote(repo_url, ref)

--- a/ci/modal_runner.py
+++ b/ci/modal_runner.py
@@ -17,7 +17,7 @@ image = (
         extra_index_url="https://download.pytorch.org/whl/cu128",
     )
     .run_commands(
-        "pip install flash-attn --no-build-isolation",
+        "CXX=g++ CC=gcc pip install flash-attn --no-build-isolation",
         gpu="L4",
     )
     .pip_install(

--- a/ci/modal_runner.py
+++ b/ci/modal_runner.py
@@ -14,6 +14,7 @@ image = (
         "wheel",
         "setuptools",
         "torch>=2.7.0",
+        "torchvision",
         extra_index_url="https://download.pytorch.org/whl/cu128",
     )
     .run_commands(


### PR DESCRIPTION
Description:
Adds a CI/CD pipeline that runs the full test suite on a GPU via Modal.

## What's included
- `.github/workflows/test.yml` — manual trigger (`workflow_dispatch`) that runs tests on Modal
- `ci/modal_runner.py` — Modal job definition using an L4 GPU with model weight caching

## How it works
On demand (via the **Run workflow** button in GitHub Actions), the pipeline:
1. Spins up an L4 GPU container on Modal
2. Clones the repo at the triggered commit
3. Runs the full pytest suite
4. Caches downloaded model weights for subsequent runs